### PR TITLE
Feature/update picard tools to 2.21.2

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -23,12 +23,18 @@
     * [v0.1.7](../merge_fastq_0.1.7/README.md)
   * Picard Tools 
     * [AddOrReplaceReadGroups v1.96](../picard_add_or_replace_read_groups_1.96/README.md)
+    * [AddOrReplaceReadGroups v2.21.2](../picard_add_or_replace_read_groups_2.21.2/README.md)
     * [CollectAlignmentSummaryMetrics v2.8.1](../picard_collect_alignment_summary_metrics_2.8.1/README.md)
+    * [CollectAlignmentSummaryMetrics v2.21.2](../picard_collect_alignment_summary_metrics_2.21.2/README.md)
     * [CollectMultipleMetrics v2.8.1](../picard_collectmultiplemetric_2.8.1/README.md)
+    * [CollectMultipleMetrics v2.21.2](../picard_collectmultiplemetric_2.21.2/README.md)
     * [FixMateInformation v1.96](../picard_fix_mate_information_1.96/README.md)
+    * [FixMateInformation v2.21.2](../picard_fix_mate_information_2.21.2/README.md)
     * [HSmetrics v2.8.1](../picard_hsmetrics_2.8.1/README.md)
+    * [HSmetrics v2.21.2](../picard_hsmetrics_2.21.2/README.md)
     * [MarkDuplicates v1.96](../picard_mark_duplicates_1.96/README.md)
     * [MarkDuplicates v2.8.1](../picard_mark_duplicates_2.8.1/README.md)
+    * [MarkDuplicates v2.21.2](../picard_mark_duplicates_2.21.2/README.md)
   * Trim Galore
     * [v0.6.2](../trim_galore_0.6.2/README.md)
   * Ubuntu utilites

--- a/picard_add_or_replace_read_groups_2.21.2/README.md
+++ b/picard_add_or_replace_read_groups_2.21.2/README.md
@@ -1,0 +1,91 @@
+# CWL and Dockerfile for running Picard - AddOrReplaceReadGroups
+
+## Version of tools in docker image (/container/Dockerfile)
+
+| Tool	| Version	| Location	|
+|---	|---	|---	|
+| picard  	| 2.21.2  	|  https://github.com/broadinstitute/picard/releases/download/2.21.2/picard.jar	|
+
+
+## CWL
+
+- CWL specification 1.0
+- Use example_inputs.yaml to see the inputs to the cwl
+- Example Command using [toil](https://toil.readthedocs.io):
+
+```bash
+    > toil-cwl-runner picard_add_or_replace_read_groups_2.21.2.cwl example_inputs.yaml
+```
+
+**If at MSK, using the JUNO cluster having installed toil version 3.19 and manually modifying [lsf.py](https://github.com/DataBiosphere/toil/blob/releases/3.19.0/src/toil/batchSystems/lsf.py#L170) by removing `type==X86_64 &&` you can use the following command**
+
+```bash
+#Using CWLTOOL
+> cwltool --singularity --non-strict /path/to/picard_add_or_replace_read_groups_2.21.2/picard_add_or_replace_read_groups_2.21.2.cwl /path/to/inputs.yaml
+
+#Using toil-cwl-runner
+> mkdir picardAddOrReplaceReadGroup_toil_log
+> toil-cwl-runner --singularity --logFile /path/to/picardAddOrReplaceReadGroup_toil_log/cwltoil.log  --jobStore /path/to/picardAddOrReplaceReadGroup_jobStore --batchSystem lsf --workDir /path/to picardAddOrReplaceReadGroup_toil_log --outdir . --writeLogs /path/to/picardAddOrReplaceReadGroup_toil_log --logLevel DEBUG --stats --retryCount 2 --disableCaching --maxLogFileSize 20000000000 /path/to/picard_add_or_replace_read_groups_2.21.2/picard_add_or_replace_read_groups_2.21.2.cwl /path/to/inputs.yaml > picardAddOrReplaceReadGroup_toil.stdout 2> picardAddOrReplaceReadGroup_toil.stderr &
+```
+
+### Usage
+
+```bash
+> toil-cwl-runner picard_add_or_replace_read_groups_2.21.2.cwl --help
+usage: picard_add_or_replace_read_groups_2.21.2.cwl [-h]
+
+positional arguments:
+  job_order             Job input json file
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --memory_per_job MEMORY_PER_JOB
+                        Memory per job in megabytes
+  --memory_overhead MEMORY_OVERHEAD
+                        Memory overhead per job in megabytes
+  --number_of_threads NUMBER_OF_THREADS
+  --input INPUT         Input file (bam or sam). Required.
+  --output_file_name OUTPUT_FILE_NAME
+                        Output file name (bam or sam). Not Required
+  --sort_order SORT_ORDER
+                        Optional sort order to output in. If not supplied
+                        OUTPUT is in the same order as INPUT.Default value:
+                        null. Possible values: {unsorted, queryname,
+                        coordinate}
+  --read_group_identifier READ_GROUP_IDENTIFIER
+                        Read Group ID Default value: 1. This option can be set
+                        to 'null' to clear the default value Required
+  --read_group_sequnecing_center READ_GROUP_SEQUNECING_CENTER
+                        Read Group sequencing center name Default value: null.
+                        Required
+  --read_group_library READ_GROUP_LIBRARY
+                        Read Group Library. Required
+  --read_group_platform_unit READ_GROUP_PLATFORM_UNIT
+                        Read Group platform unit (eg. run barcode) Required.
+  --read_group_sample_name READ_GROUP_SAMPLE_NAME
+                        Read Group sample name. Required
+  --read_group_sequencing_platform READ_GROUP_SEQUENCING_PLATFORM
+                        Read Group platform (e.g. illumina, solid) Required.
+  --read_group_description READ_GROUP_DESCRIPTION
+                        Read Group description Default value: null.
+  --read_group_run_date READ_GROUP_RUN_DATE
+                        Read Group run date Default value: null.
+  --tmp_dir TMP_DIR     This option may be specified 0 or more times
+  --validation_stringency VALIDATION_STRINGENCY
+                        Validation stringency for all SAM files read by this
+                        program. Setting stringency to SILENT can improve
+                        performance when processing a BAM file in which
+                        variable-length data (read, qualities, tags) do not
+                        otherwise need to be decoded. Default value: STRICT.
+                        This option can be set to 'null' to clear the default
+                        value. Possible values: {STRICT,LENIENT, SILENT}
+  --bam_compression_level BAM_COMPRESSION_LEVEL
+                        Compression level for all compressed files created
+                        (e.g. BAM and GELI). Default value:5. This option can
+                        be set to 'null' to clear the default value.
+  --create_bam_index    Whether to create a BAM index when writing a
+                        coordinate-sorted BAM file. Default value:false. This
+                        option can be set to 'null' to clear the default
+                        value. Possible values:{true, false}
+```
+

--- a/picard_add_or_replace_read_groups_2.21.2/README.md
+++ b/picard_add_or_replace_read_groups_2.21.2/README.md
@@ -1,6 +1,6 @@
-# CWL and Dockerfile for running Picard - AddOrReplaceReadGroups
+# CWL for running Picard - AddOrReplaceReadGroups
 
-## Version of tools in docker image (/container/Dockerfile)
+## Version of tools in docker image
 
 | Tool	| Version	| Location	|
 |---	|---	|---	|

--- a/picard_add_or_replace_read_groups_2.21.2/example_inputs.yaml
+++ b/picard_add_or_replace_read_groups_2.21.2/example_inputs.yaml
@@ -1,0 +1,20 @@
+bam_compression_level: 
+create_bam_index: true
+input:
+  class: File
+  path: "/path/to/bam"
+memory_overhead: 
+memory_per_job: 
+number_of_threads: 
+output_file_name: somename_srt.bam
+read_group_description: 
+read_group_identifier: test
+read_group_library: 1
+read_group_platform_unit: bc01
+read_group_run_date: 
+read_group_sample_name: seracare
+read_group_sequencing_platform: Illumina
+read_group_sequnecing_center: msk
+sort_order: 
+tmp_dir: 
+validation_stringency: 

--- a/picard_add_or_replace_read_groups_2.21.2/picard_add_or_replace_read_groups_2.21.2.cwl
+++ b/picard_add_or_replace_read_groups_2.21.2/picard_add_or_replace_read_groups_2.21.2.cwl
@@ -1,0 +1,212 @@
+class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  dct: 'http://purl.org/dc/terms/'
+  doap: 'http://usefulinc.com/ns/doap#'
+  foaf: 'http://xmlns.com/foaf/0.1/'
+id: picard_add_or_replace_read_groups_1_96
+baseCommand:
+  - java
+inputs:
+  - id: memory_per_job
+    type: int?
+    doc: Memory per job in megabytes
+  - id: memory_overhead
+    type: int?
+    doc: Memory overhead per job in megabytes
+  - id: number_of_threads
+    type: int?
+  - id: input
+    type: File
+    inputBinding:
+      position: 0
+      prefix: I=
+      separate: false
+    doc: Input file ( sam).  Required.
+  - id: output_file_name
+    type: string?
+    doc: Output file name (bam or sam). Not Required
+  - id: sort_order
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: SO=
+      separate: false
+    doc: >-
+      Optional sort order to output in. If not supplied OUTPUT is in the same
+      order as INPUT.Default value: null. Possible values: {unsorted, queryname,
+      coordinate}
+  - id: read_group_identifier
+    type: string
+    inputBinding:
+      position: 0
+      prefix: RGID=
+      separate: false
+    doc: >-
+      Read Group ID  Default value: 1. This option can be set to 'null' to clear
+      the default value  Required
+  - id: read_group_sequnecing_center
+    type: string
+    inputBinding:
+      position: 0
+      prefix: RGCN=
+      separate: false
+    doc: 'Read Group sequencing center name  Default value: null. Required'
+  - id: read_group_library
+    type: int
+    inputBinding:
+      position: 0
+      prefix: RGLB=
+      separate: false
+    doc: Read Group Library.  Required
+  - id: read_group_platform_unit
+    type: string
+    inputBinding:
+      position: 0
+      prefix: RGPU=
+      separate: false
+    doc: Read Group platform unit (eg. run barcode)  Required.
+  - id: read_group_sample_name
+    type: string
+    inputBinding:
+      position: 0
+      prefix: RGSM=
+      separate: false
+    doc: Read Group sample name.  Required
+  - id: read_group_sequencing_platform
+    type: string
+    inputBinding:
+      position: 0
+      prefix: RGPL=
+      separate: false
+    doc: 'Read Group platform (e.g. illumina, solid)  Required.'
+  - id: read_group_description
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: RGDS=
+      separate: false
+    doc: 'Read Group description  Default value: null.'
+  - id: read_group_run_date
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: RGDT=
+      separate: false
+    doc: 'Read Group run date  Default value: null.'
+  - id: tmp_dir
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: TMP_DIR=
+      separate: false
+    doc: This option may be specified 0 or more times
+  - id: validation_stringency
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+    doc: >-
+      Validation stringency for all SAM files read by this program.  Setting
+      stringency to SILENT can improve performance when processing a BAM file in
+      which variable-length data (read, qualities, tags) do not otherwise need
+      to be decoded.  Default value: STRICT. This option can be set to 'null' to
+      clear the default value. Possible values: {STRICT,LENIENT, SILENT}
+  - id: bam_compression_level
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: COMPRESSION_LEVEL=
+      separate: false
+    doc: >-
+      Compression level for all compressed files created (e.g. BAM and GELI). 
+      Default value:5. This option can be set to 'null' to clear the default
+      value.
+  - default: true
+    id: create_bam_index
+    type: boolean?
+    inputBinding:
+      position: 0
+      prefix: CREATE_INDEX=true
+    doc: >-
+      Whether to create a BAM index when writing a coordinate-sorted BAM file. 
+      Default value:false. This option can be set to 'null' to clear the default
+      value. Possible values:{true, false}
+outputs:
+  - id: bam
+    type: File
+    outputBinding:
+      glob: |-
+        ${
+            if(inputs.output_file_name)
+                return inputs.output_file_name;
+            return inputs.input.basename.replace(/.sam$/, '_srt.bam');
+        }
+    secondaryFiles:
+      - ^.bai
+label: picard_add_or_replace_read_groups_1.96
+arguments:
+  - position: 0
+    valueFrom: |-
+      ${
+        if(inputs.memory_per_job && inputs.memory_overhead) {
+          if(inputs.memory_per_job % 1000 == 0) {
+            return "-Xmx" + (inputs.memory_per_job/1000).toString() + "G"
+          }
+          else {
+            return "-Xmx" + Math.floor((inputs.memory_per_job/1000)).toString() + "G"
+          }
+        }
+        else if (inputs.memory_per_job && !inputs.memory_overhead){
+          if(inputs.memory_per_job % 1000 == 0) {
+            return "-Xmx" + (inputs.memory_per_job/1000).toString() + "G"
+          }
+          else {
+            return "-Xmx" + Math.floor((inputs.memory_per_job/1000)).toString() + "G"
+          }
+        }
+        else if(!inputs.memory_per_job && inputs.memory_overhead){
+          return "-Xmx15G"
+        }
+        else {
+            return "-Xmx15G"
+        }
+      }
+  - position: 0
+    prefix: '-jar'
+    valueFrom: /usr/local/bin/AddOrReplaceReadGroups.jar
+  - position: 0
+    prefix: O=
+    separate: false
+    valueFrom: |-
+      ${
+          if(inputs.output_file_name)
+              return inputs.output_file_name;
+            return inputs.input.basename.replace(/.sam$/, '_srt.bam');
+      }
+requirements:
+  - class: ResourceRequirement
+    ramMin: 16000
+    coresMin: 2
+  - class: DockerRequirement
+    dockerPull: 'mskaccess/picard_1.96:0.6.2'
+  - class: InlineJavascriptRequirement
+'dct:contributor':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'dct:creator':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'doap:release':
+  - class: 'doap:Version'
+    'doap:name': picard
+    'doap:revision': 1.96

--- a/picard_add_or_replace_read_groups_2.21.2/picard_add_or_replace_read_groups_2.21.2.cwl
+++ b/picard_add_or_replace_read_groups_2.21.2/picard_add_or_replace_read_groups_2.21.2.cwl
@@ -4,7 +4,8 @@ $namespaces:
   dct: 'http://purl.org/dc/terms/'
   doap: 'http://usefulinc.com/ns/doap#'
   foaf: 'http://xmlns.com/foaf/0.1/'
-id: picard_add_or_replace_read_groups_1_96
+  sbg: 'https://www.sevenbridges.com/'
+id: picard_add_or_replace_read_groups_2.21.2
 baseCommand:
   - java
 inputs:
@@ -145,7 +146,7 @@ outputs:
         }
     secondaryFiles:
       - ^.bai
-label: picard_add_or_replace_read_groups_1.96
+label: picard_add_or_replace_read_groups_2.21.2
 arguments:
   - position: 0
     valueFrom: |-
@@ -175,7 +176,10 @@ arguments:
       }
   - position: 0
     prefix: '-jar'
-    valueFrom: /usr/local/bin/AddOrReplaceReadGroups.jar
+    valueFrom: /usr/picard/picard.jar
+  - position: 0
+    separate: false
+    valueFrom: AddOrReplaceReadGroups
   - position: 0
     prefix: O=
     separate: false
@@ -187,10 +191,10 @@ arguments:
       }
 requirements:
   - class: ResourceRequirement
-    ramMin: 16000
+    ramMin: 17000
     coresMin: 2
   - class: DockerRequirement
-    dockerPull: 'mskaccess/picard_1.96:0.6.2'
+    dockerPull: 'broadinstitute/picard:2.21.2'
   - class: InlineJavascriptRequirement
 'dct:contributor':
   - class: 'foaf:Organization'
@@ -209,4 +213,4 @@ requirements:
 'doap:release':
   - class: 'doap:Version'
     'doap:name': picard
-    'doap:revision': 1.96
+    'doap:revision': 2.21.2

--- a/picard_collect_alignment_summary_metrics_2.21.2/README.md
+++ b/picard_collect_alignment_summary_metrics_2.21.2/README.md
@@ -1,0 +1,78 @@
+# CWL for running Picard - CollectAlignmentSummaryMetrics
+
+## Version of tools in docker image
+
+| Tool	| Version	| Location	|
+|---	|---	|---	|
+| picard  	| 2.21.2  	|  https://github.com/broadinstitute/picard/releases/download/2.21.2/picard.jar	|
+
+
+## CWL
+
+- CWL specification 1.0
+- Use example_inputs.yaml to see the inputs to the cwl
+- Example Command using [toil](https://toil.readthedocs.io):
+
+```bash
+    > toil-cwl-runner picard_collect_alignment_summary_metrics_2.21.2.cwl example_inputs.yaml
+```
+
+### Usage
+
+```bash
+> usage: picard_collect_alignment_summary_metrics_2.21.2.cwl [-h]
+
+positional arguments:
+  job_order             Job input json file
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --memory_per_job MEMORY_PER_JOB
+                        Memory per job in megabytes
+  --memory_overhead MEMORY_OVERHEAD
+                        Memory overhead per job in megabytes
+  --number_of_threads NUMBER_OF_THREADS
+  --input INPUT         Input file (bam or sam). Required.
+  --output_file_name OUTPUT_FILE_NAME
+                        Output file (bam or sam).
+  --metrics_acciumulation_level METRICS_ACCIUMULATION_LEVEL
+                        The level(s) at which to accumulate metrics. Default
+                        value: [ALL_READS]. This option can be set to 'null'
+                        to clear the default value. Possible values:
+                        {ALL_READS, SAMPLE, LIBRARY, READ_GROUP} This option
+                        may be specified 0 or more times. This option can be
+                        set to 'null' to clear the default list.
+  --max_insert_size MAX_INSERT_SIZE
+                        Paired-end reads above this insert size will be
+                        considered chimeric along with inter-chromosomal
+                        pairs. Default value: 100000. This option can be set
+                        to 'null' to clear the default value.
+  --tmp_dir TMP_DIR     This option may be specified 0 or more times
+  --validation_stringency VALIDATION_STRINGENCY
+                        Validation stringency for all SAM files read by this
+                        program. Setting stringency to SILENT can improve
+                        performance when processing a BAM file in which
+                        variable-length data (read, qualities, tags) do not
+                        otherwise need to be decoded. Default value: STRICT.
+                        This option can be set to 'null' to clear the default
+                        value. Possible values: {STRICT,LENIENT, SILENT}
+  --bam_compression_level BAM_COMPRESSION_LEVEL
+                        Compression level for all compressed files created
+                        (e.g. BAM and GELI). Default value:5. This option can
+                        be set to 'null' to clear the default value.
+  --create_bam_index    Whether to create a BAM index when writing a
+                        coordinate-sorted BAM file. Default value:false. This
+                        option can be set to 'null' to clear the default
+                        value. Possible values:{true, false}
+  --assume_sorted
+  --reference_sequence REFERENCE_SEQUENCE
+                        Reference sequence file. Note that while this argument
+                        isn't required, without it only a small subset of the
+                        metrics will be calculated. Note also that if a
+                        reference sequence is provided, it must be accompanied
+                        by a sequence dictionary. Default value: null.
+  --stop_after STOP_AFTER
+                        Stop after processing N reads, mainly for debugging.
+                        Default value: 0. This option can be set to 'null' to
+                        clear the default value.
+```

--- a/picard_collect_alignment_summary_metrics_2.21.2/example_inputs.yaml
+++ b/picard_collect_alignment_summary_metrics_2.21.2/example_inputs.yaml
@@ -1,0 +1,26 @@
+assume_sorted: true
+bam_compression_level: null
+create_bam_index: null
+input:
+  class: File
+  metadata: {}
+  path: "/path/to/bam"
+  secondaryFiles:
+    - class: File
+      path: "/path/to/bam.bai"
+max_insert_size: null
+memory_overhead: null
+memory_per_job: null
+metrics_acciumulation_level: null
+number_of_threads: null
+output_file_name: null
+reference_sequence:
+  class: File
+  metadata: {}
+  path: "/path/to/reference.fasta"
+  secondaryFiles:
+    - class: File
+      path: "/path/to/reference.dict"
+stop_after: null
+tmp_dir: null
+validation_stringency: null

--- a/picard_collect_alignment_summary_metrics_2.21.2/picard_collect_alignment_summary_metrics_2.21.2.cwl
+++ b/picard_collect_alignment_summary_metrics_2.21.2/picard_collect_alignment_summary_metrics_2.21.2.cwl
@@ -1,0 +1,178 @@
+class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  dct: 'http://purl.org/dc/terms/'
+  doap: 'http://usefulinc.com/ns/doap#'
+  foaf: 'http://xmlns.com/foaf/0.1/'
+id: picard_collect_alignment_summary_metrics_2.8.1
+baseCommand:
+  - java
+inputs:
+  - id: memory_per_job
+    type: int?
+    doc: Memory per job in megabytes
+  - id: memory_overhead
+    type: int?
+    doc: Memory overhead per job in megabytes
+  - id: number_of_threads
+    type: int?
+  - id: input
+    type: File
+    inputBinding:
+      position: 0
+      prefix: I=
+      separate: false
+    doc: Input file (bam or sam).  Required.
+  - id: output_file_name
+    type: string?
+    doc: Output file (bam or sam).
+  - id: metrics_acciumulation_level
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: LEVEL=
+      separate: false
+    doc: >-
+      The level(s) at which to accumulate metrics. Default value: [ALL_READS].
+      This option can be set to 'null' to clear the default value. Possible
+      values: {ALL_READS, SAMPLE, LIBRARY, READ_GROUP} This option may be
+      specified 0 or more times. This option can be set to 'null' to clear the
+      default list.
+  - id: max_insert_size
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: MAX_INSERT_SIZE=
+      separate: false
+    doc: >-
+      Paired-end reads above this insert size will be considered chimeric along
+      with inter-chromosomal pairs. Default value: 100000. This option can be
+      set to 'null' to clear the default value.
+  - id: tmp_dir
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: TMP_DIR=
+      separate: false
+    doc: This option may be specified 0 or more times
+  - id: validation_stringency
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+    doc: >-
+      Validation stringency for all SAM files read by this program.  Setting
+      stringency to SILENT can improve performance when processing a BAM file in
+      which variable-length data (read, qualities, tags) do not otherwise need
+      to be decoded.  Default value: STRICT. This option can be set to 'null' to
+      clear the default value. Possible values: {STRICT,LENIENT, SILENT}
+  - default: true
+    id: assume_sorted
+    type: boolean?
+    inputBinding:
+      position: 0
+      prefix: AS=true
+  - id: reference_sequence
+    type: File
+    inputBinding:
+      position: 0
+      prefix: R=
+      separate: false
+    doc: >-
+      Reference sequence file. Note that while this argument isn't required,
+      without it only a small subset of the metrics will be calculated. Note
+      also that if a reference sequence is provided, it must be accompanied by a
+      sequence dictionary. Default value: null.
+    secondaryFiles:
+      - ^.dict
+  - id: stop_after
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: STOP_AFTER=
+    doc: >-
+      Stop after processing N reads, mainly for debugging. Default value: 0.
+      This option can be set to 'null' to clear the default value.
+outputs:
+  - id: alignment_metrics
+    type: File
+    outputBinding:
+      glob: |-
+        ${
+            if(inputs.output_file_name){
+                return inputs.output_file_name
+            } else {
+                return inputs.input.basename.replace(/.bam/,'_alignment_metrics.txt')
+            }
+        }
+label: picard_collect_alignment_summary_metrics_2.8.1
+arguments:
+  - position: 0
+    valueFrom: |-
+      ${
+         if(inputs.memory_per_job && inputs.memory_overhead) {
+             if(inputs.memory_per_job % 1000 == 0) {
+                 return "-Xmx" + (inputs.memory_per_job/1000).toString() + "G"
+             }
+             else {
+                 return "-Xmx" + Math.floor((inputs.memory_per_job/1000)).toString() + "G"
+             }
+         }
+         else if (inputs.memory_per_job && !inputs.memory_overhead){
+             if(inputs.memory_per_job % 1000 == 0) {
+                 return "-Xmx" + (inputs.memory_per_job/1000).toString() + "G"
+             }
+             else {
+                 return "-Xmx" + Math.floor((inputs.memory_per_job/1000)).toString() + "G"
+             }
+         }
+         else if(!inputs.memory_per_job && inputs.memory_overhead){
+             return "-Xmx8G"
+         }
+         else {
+             return "-Xmx8G"
+         }
+           
+       }
+  - position: 0
+    prefix: '-jar'
+    valueFrom: /usr/local/bin/picard.jar
+  - position: 0
+    valueFrom: CollectAlignmentSummaryMetrics
+  - position: 0
+    prefix: O=
+    separate: false
+    valueFrom: |-
+      ${
+        if(inputs.output_file_name){
+            return inputs.output_file_name
+        } else {
+            return inputs.input.basename.replace(/.bam/,'_alignment_metrics.txt')
+        }
+      }
+requirements:
+  - class: ResourceRequirement
+    ramMin: 12000
+    coresMin: 1
+  - class: DockerRequirement
+    dockerPull: 'mskaccess/picard:0.6.2'
+  - class: InlineJavascriptRequirement
+'dct:contributor':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'dct:creator':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'doap:release':
+  - class: 'doap:Version'
+    'doap:name': picard
+    'doap:revision': 2.8.1

--- a/picard_collect_alignment_summary_metrics_2.8.1/picard_collect_alignment_summary_metrics_2.8.1.cwl
+++ b/picard_collect_alignment_summary_metrics_2.8.1/picard_collect_alignment_summary_metrics_2.8.1.cwl
@@ -4,7 +4,8 @@ $namespaces:
   dct: 'http://purl.org/dc/terms/'
   doap: 'http://usefulinc.com/ns/doap#'
   foaf: 'http://xmlns.com/foaf/0.1/'
-id: picard_collect_alignment_summary_metrics_2.8.1
+  sbg: 'https://www.sevenbridges.com/'
+id: picard_collect_alignment_summary_metrics_2.21.2
 baseCommand:
   - java
 inputs:
@@ -106,7 +107,7 @@ outputs:
                 return inputs.input.basename.replace(/.bam/,'_alignment_metrics.txt')
             }
         }
-label: picard_collect_alignment_summary_metrics_2.8.1
+label: picard_collect_alignment_summary_metrics_2.21.2
 arguments:
   - position: 0
     valueFrom: |-
@@ -137,7 +138,7 @@ arguments:
        }
   - position: 0
     prefix: '-jar'
-    valueFrom: /usr/local/bin/picard.jar
+    valueFrom: /usr/picard/picard.jar
   - position: 0
     valueFrom: CollectAlignmentSummaryMetrics
   - position: 0
@@ -156,7 +157,7 @@ requirements:
     ramMin: 12000
     coresMin: 1
   - class: DockerRequirement
-    dockerPull: 'mskaccess/picard:0.6.2'
+    dockerPull: 'broadinstitute/picard:2.21.2'
   - class: InlineJavascriptRequirement
 'dct:contributor':
   - class: 'foaf:Organization'
@@ -175,4 +176,4 @@ requirements:
 'doap:release':
   - class: 'doap:Version'
     'doap:name': picard
-    'doap:revision': 2.8.1
+    'doap:revision': 2.21.2

--- a/picard_collectmultiplemetric_2.21.2/README.md
+++ b/picard_collectmultiplemetric_2.21.2/README.md
@@ -1,0 +1,78 @@
+# CWL for running Picard - CollectMultipleMetrics
+
+## Version of tools in docker image
+
+| Tool	| Version	| Location	|
+|---	|---	|---	|
+| picard  	| 2.21.2  	|  https://github.com/broadinstitute/picard/releases/download/2.21.2/picard.jar	|
+
+
+## CWL
+
+- CWL specification 1.0
+- Use example_inputs.yaml to see the inputs to the cwl
+- Example Command using [toil](https://toil.readthedocs.io):
+
+```bash
+    > toil-cwl-runner picard_collectmultiplemetrics_2.21.2.cwl example_inputs.yaml
+```
+
+### Usage
+
+```bash
+> usage: picard_collectmultiplemetrics_2.21.2.cwl [-h]
+
+positional arguments:
+  job_order             Job input json file
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --memory_per_job MEMORY_PER_JOB
+                        Memory per job in megabytes
+  --memory_overhead MEMORY_OVERHEAD
+                        Memory overhead per job in megabytes
+  --number_of_threads NUMBER_OF_THREADS
+  --input INPUT         Input file (bam or sam). Required.
+  --output_file_name OUTPUT_FILE_NAME
+                        Output file (bam or sam).
+  --metrics_acciumulation_level METRICS_ACCIUMULATION_LEVEL
+                        The level(s) at which to accumulate metrics. Default
+                        value: [ALL_READS]. This option can be set to 'null'
+                        to clear the default value. Possible values:
+                        {ALL_READS, SAMPLE, LIBRARY, READ_GROUP} This option
+                        may be specified 0 or more times. This option can be
+                        set to 'null' to clear the default list.
+  --max_insert_size MAX_INSERT_SIZE
+                        Paired-end reads above this insert size will be
+                        considered chimeric along with inter-chromosomal
+                        pairs. Default value: 100000. This option can be set
+                        to 'null' to clear the default value.
+  --tmp_dir TMP_DIR     This option may be specified 0 or more times
+  --validation_stringency VALIDATION_STRINGENCY
+                        Validation stringency for all SAM files read by this
+                        program. Setting stringency to SILENT can improve
+                        performance when processing a BAM file in which
+                        variable-length data (read, qualities, tags) do not
+                        otherwise need to be decoded. Default value: STRICT.
+                        This option can be set to 'null' to clear the default
+                        value. Possible values: {STRICT,LENIENT, SILENT}
+  --bam_compression_level BAM_COMPRESSION_LEVEL
+                        Compression level for all compressed files created
+                        (e.g. BAM and GELI). Default value:5. This option can
+                        be set to 'null' to clear the default value.
+  --create_bam_index    Whether to create a BAM index when writing a
+                        coordinate-sorted BAM file. Default value:false. This
+                        option can be set to 'null' to clear the default
+                        value. Possible values:{true, false}
+  --assume_sorted
+  --reference_sequence REFERENCE_SEQUENCE
+                        Reference sequence file. Note that while this argument
+                        isn't required, without it only a small subset of the
+                        metrics will be calculated. Note also that if a
+                        reference sequence is provided, it must be accompanied
+                        by a sequence dictionary. Default value: null.
+  --stop_after STOP_AFTER
+                        Stop after processing N reads, mainly for debugging.
+                        Default value: 0. This option can be set to 'null' to
+                        clear the default value.
+```

--- a/picard_collectmultiplemetric_2.21.2/example_inputs.yml
+++ b/picard_collectmultiplemetric_2.21.2/example_inputs.yml
@@ -1,0 +1,18 @@
+input:
+  class: File
+  path: "Sample.bam"
+assume_sorted:
+bam_compression_level:
+create_bam_index:
+dbsnp_file:
+file_extension:
+include_unpaired:
+intervals_file:
+memory_overhead:
+memory_per_job:
+metric_accumulation_level:
+number_of_threads:
+output_file_name:
+program_list:
+stop_after:
+validation_stringency:

--- a/picard_collectmultiplemetric_2.21.2/picard_collectmultiplemetrics_2.21.2.cwl
+++ b/picard_collectmultiplemetric_2.21.2/picard_collectmultiplemetrics_2.21.2.cwl
@@ -1,0 +1,268 @@
+class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  dct: 'http://purl.org/dc/terms/'
+  doap: 'http://usefulinc.com/ns/doap#'
+  foaf: 'http://xmlns.com/foaf/0.1/'
+  sbg: 'https://www.sevenbridges.com/'
+id: picard_collectmultiplemetrics_2_8_1
+baseCommand:
+  - java
+inputs:
+  - id: memory_per_job
+    type: int?
+    doc: Memory per job in megabytes
+  - id: memory_overhead
+    type: int?
+    doc: Memory overhead per job in megabytes
+  - id: number_of_threads
+    type: int?
+  - id: input
+    type: File
+    inputBinding:
+      position: 0
+      prefix: I=
+      separate: false
+    doc: Input file (bam or sam).  Required.
+  - id: output_file_name
+    type: string?
+    doc: Output file (bam or sam).
+  - id: validation_stringency
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+    doc: >-
+      Validation stringency for all SAM files read by this program.  Setting
+      stringency to SILENT can improve performance when processing a BAM file in
+      which variable-length data (read, qualities, tags) do not otherwise need
+      to be decoded.  Default value: STRICT. This option can be set to 'null' to
+      clear the default value. Possible values: {STRICT,LENIENT, SILENT}
+  - default: true
+    id: assume_sorted
+    type: boolean?
+    inputBinding:
+      position: 0
+      prefix: AS=true
+      separate: false
+  - id: bam_compression_level
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: COMPRESSION_LEVEL=
+      separate: false
+    doc: >-
+      Compression level for all compressed files created (e.g. BAM and GELI). 
+      Default value:5. This option can be set to 'null' to clear the default
+      value.
+  - default: true
+    id: create_bam_index
+    type: boolean?
+    inputBinding:
+      position: 0
+      prefix: CREATE_INDEX=true
+      separate: false
+    doc: >-
+      Whether to create a BAM index when writing a coordinate-sorted BAM file. 
+      Default value:false. This option can be set to 'null' to clear the default
+      value. Possible values:{true, false}
+  - id: stop_after
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: STOP_AFTER=
+      separate: false
+    doc: >-
+      Stop after processing N reads, mainly for debugging. Default value: 0.
+      This option can be set to 'null' to clear the default value.
+  - id: metric_accumulation_level
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: METRIC_ACCUMULATION_LEVEL=
+      separate: false
+    doc: >-
+      The level(s) at which to accumulate metrics. Default value: [ALL_READS].
+      This option can be set to 'null' to clear the default value. Possible
+      values: {ALL_READS, SAMPLE, LIBRARY, READ_GROUP} This option may be
+      specified 0 or more times. This option can be set to 'null' to clear the
+      default list.
+  - id: file_extension
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: FILE_EXTENSION=
+      separate: false
+    doc: >-
+      Append the given file extension to all metric file names (ex.
+      OUTPUT.insert_size_metrics.EXT). None if null Default value: null.
+  - id: program_list
+    type: 'string[]?'
+    inputBinding:
+      position: 0
+      prefix: PROGRAM=
+      separate: false
+    doc: >-
+      Set of metrics programs to apply during the pass through the SAM file.
+      Default value: [CollectAlignmentSummaryMetrics,
+      CollectBaseDistributionByCycle, CollectInsertSizeMetrics,
+      MeanQualityByCycle, QualityScoreDistribution]. This option can be set to
+      'null' to clear the default value. Possible values:
+      {CollectAlignmentSummaryMetrics, CollectInsertSizeMetrics,
+      QualityScoreDistribution, MeanQualityByCycle,
+      CollectBaseDistributionByCycle, CollectGcBiasMetrics, RnaSeqMetrics,
+      CollectSequencingArtifactMetrics, CollectQualityYieldMetrics} This option
+      may be specified 0 or more times. This option can be set to 'null' to
+      clear the default list.
+  - id: intervals_file
+    type: File?
+    inputBinding:
+      position: 0
+      prefix: INTERVALS=
+      separate: false
+    doc: >-
+      An optional list of intervals to restrict analysis to. Only pertains to
+      some of the PROGRAMs. Programs whose stand-alone CLP does not have an
+      INTERVALS argument will silently ignore this argument. Default value:
+      null.
+  - id: dbsnp_file
+    type: File?
+    inputBinding:
+      position: 0
+      prefix: DB_SNP=
+      separate: false
+    doc: >-
+      VCF format dbSNP file, used to exclude regions around known polymorphisms
+      from analysis by some PROGRAMs; PROGRAMs whose CLP doesn't allow for this
+      argument will quietly ignore it. Default value: null.
+  - id: include_unpaired
+    type: boolean?
+    inputBinding:
+      position: 0
+      prefix: INCLUDE_UNPAIRED=true
+      separate: false
+    doc: >-
+      Include unpaired reads in CollectSequencingArtifactMetrics. If set to true
+      then all paired reads will be included as well - MINIMUM_INSERT_SIZE and
+      MAXIMUM_INSERT_SIZE will be ignored in CollectSequencingArtifactMetrics.
+      Default value: false. This option can be set to 'null' to clear the
+      default value. Possible values: {true, false}
+outputs:
+  - id: alignment_summary_metrics
+    type: File?
+    outputBinding:
+      glob: '*alignment_summary_metrics'
+  - id: bait_bias_detail_metrics
+    type: File?
+    outputBinding:
+      glob: '*bait_bias_detail_metrics'
+  - id: bait_bias_summary_metrics
+    type: File?
+    outputBinding:
+      glob: '*bait_bias_summary_metrics'
+  - id: base_distribution_by_cycle_metrics
+    type: File?
+    outputBinding:
+      glob: '*base_distribution_by_cycle_metrics'
+  - id: base_distribution_by_cycle_pdf
+    type: File?
+    outputBinding:
+      glob: '*base_distribution_by_cycle.pdf'
+  - id: error_summary_metrics
+    type: File?
+    outputBinding:
+      glob: '*error_summary_metrics'
+  - id: gc_bias_detail_metrics
+    type: File?
+    outputBinding:
+      glob: '*gc_bias.detail_metrics'
+  - id: gc_bias_pdf
+    type: File?
+    outputBinding:
+      glob: '*gc_bias.pdf'
+  - id: gc_bias_summary_metrics
+    type: File?
+    outputBinding:
+      glob: '*gc_bias.summary_metrics'
+  - id: insert_size_histogram_pdf
+    type: File?
+    outputBinding:
+      glob: '*insert_size_histogram.pdf'
+  - id: insert_size_metrics
+    type: File?
+    outputBinding:
+      glob: '*insert_size_metrics'
+  - id: pre_adapter_detail_metrics
+    type: File?
+    outputBinding:
+      glob: '*pre_adapter_detail_metrics'
+  - id: pre_adapter_summary_metrics
+    type: File?
+    outputBinding:
+      glob: '*pre_adapter_summary_metrics'
+  - id: quality_by_cycle_metrics
+    type: File?
+    outputBinding:
+      glob: '*quality_by_cycle_metrics'
+  - id: quality_by_cycle_pdf
+    type: File?
+    outputBinding:
+      glob: '*quality_by_cycle.pdf'
+  - id: quality_distribution_metrics
+    type: File?
+    outputBinding:
+      glob: '*quality_distribution_metrics'
+  - id: quality_distribution_pdf
+    type: File?
+    outputBinding:
+      glob: '*quality_distribution.pdf'
+label: picard_collectmultiplemetrices_2.8.1
+arguments:
+  - position: 0
+    prefix: ''
+    separate: false
+    valueFrom: "${\n  if(inputs.memory_per_job && inputs.memory_overhead) {\n   \n    if(inputs.memory_per_job % 1000 == 0) {\n    \t\n      return \"-Xmx\" + (inputs.memory_per_job/1000).toString() + \"G\"\n    }\n    else {\n      \n      return \"-Xmx\" + Math.floor((inputs.memory_per_job/1000)).toString() + \"G\" \n    }\n  }\n  else if (inputs.memory_per_job && !inputs.memory_overhead){\n    \n    if(inputs.memory_per_job % 1000 == 0) {\n    \t\n      return \"-Xmx\" + (inputs.memory_per_job/1000).toString() + \"G\"\n    }\n    else {\n      \n      return \"-Xmx\" + Math.floor((inputs.memory_per_job/1000)).toString() + \"G\" \n    }\n  }\n  else if(!inputs.memory_per_job && inputs.memory_overhead){\n    \n    return \"-Xmx15G\"\n  }\n  else {\n    \n  \treturn \"-Xmx15G\"\n  }\n}"
+  - position: 0
+    prefix: '-jar'
+    valueFrom: /usr/local/bin/picard.jar
+  - position: 0
+    prefix: ''
+    separate: false
+    valueFrom: CollectMultipleMetrics
+  - position: 0
+    prefix: O=
+    separate: false
+    valueFrom: |-
+      ${
+          if(inputs.output_file_name){
+              return inputs.output_file_name
+          } else {
+              return inputs.input.basename.replace(/.bam/,'_multiple_metrics')
+          }
+      }
+requirements:
+  - class: ResourceRequirement
+    ramMin: 10000
+    coresMin: 8
+  - class: DockerRequirement
+    dockerPull: 'mskaccess/picard:0.6.2'
+  - class: InlineJavascriptRequirement
+'dct:contributor':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:sumans@mskcc.org'
+        'foaf:name': Shalabh Suman
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'dct:creator':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:sumans@mskcc.org'
+        'foaf:name': Shalabh Suman
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'doap:release':
+  - class: 'doap:Version'
+    'doap:name': picard
+    'doap:revision': 2.8.1

--- a/picard_collectmultiplemetric_2.21.2/picard_collectmultiplemetrics_2.21.2.cwl
+++ b/picard_collectmultiplemetric_2.21.2/picard_collectmultiplemetrics_2.21.2.cwl
@@ -5,7 +5,7 @@ $namespaces:
   doap: 'http://usefulinc.com/ns/doap#'
   foaf: 'http://xmlns.com/foaf/0.1/'
   sbg: 'https://www.sevenbridges.com/'
-id: picard_collectmultiplemetrics_2_8_1
+id: picard_collectmultiplemetrics_2.21.2
 baseCommand:
   - java
 inputs:
@@ -217,7 +217,7 @@ outputs:
     type: File?
     outputBinding:
       glob: '*quality_distribution.pdf'
-label: picard_collectmultiplemetrices_2.8.1
+label: picard_collectmultiplemetrices_2.21.2
 arguments:
   - position: 0
     prefix: ''
@@ -225,7 +225,7 @@ arguments:
     valueFrom: "${\n  if(inputs.memory_per_job && inputs.memory_overhead) {\n   \n    if(inputs.memory_per_job % 1000 == 0) {\n    \t\n      return \"-Xmx\" + (inputs.memory_per_job/1000).toString() + \"G\"\n    }\n    else {\n      \n      return \"-Xmx\" + Math.floor((inputs.memory_per_job/1000)).toString() + \"G\" \n    }\n  }\n  else if (inputs.memory_per_job && !inputs.memory_overhead){\n    \n    if(inputs.memory_per_job % 1000 == 0) {\n    \t\n      return \"-Xmx\" + (inputs.memory_per_job/1000).toString() + \"G\"\n    }\n    else {\n      \n      return \"-Xmx\" + Math.floor((inputs.memory_per_job/1000)).toString() + \"G\" \n    }\n  }\n  else if(!inputs.memory_per_job && inputs.memory_overhead){\n    \n    return \"-Xmx15G\"\n  }\n  else {\n    \n  \treturn \"-Xmx15G\"\n  }\n}"
   - position: 0
     prefix: '-jar'
-    valueFrom: /usr/local/bin/picard.jar
+    valueFrom: /usr/picard/picard.jar
   - position: 0
     prefix: ''
     separate: false
@@ -246,7 +246,7 @@ requirements:
     ramMin: 10000
     coresMin: 8
   - class: DockerRequirement
-    dockerPull: 'mskaccess/picard:0.6.2'
+    dockerPull: 'broadinstitute/picard:2.21.2'
   - class: InlineJavascriptRequirement
 'dct:contributor':
   - class: 'foaf:Organization'
@@ -259,10 +259,10 @@ requirements:
   - class: 'foaf:Organization'
     'foaf:member':
       - class: 'foaf:Person'
-        'foaf:mbox': 'mailto:sumans@mskcc.org'
-        'foaf:name': Shalabh Suman
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
     'foaf:name': Memorial Sloan Kettering Cancer Center
 'doap:release':
   - class: 'doap:Version'
     'doap:name': picard
-    'doap:revision': 2.8.1
+    'doap:revision': 2.21.2

--- a/picard_fix_mate_information_2.21.2/README.md
+++ b/picard_fix_mate_information_2.21.2/README.md
@@ -1,0 +1,72 @@
+# CWL for running Picard - FixMateInformation
+
+## Version of tools in docker image
+
+| Tool	| Version	| Location	|
+|---	|---	|---	|
+| picard  	| 2.21.2  	|  https://github.com/broadinstitute/picard/releases/download/2.21.2/picard.jar	|
+
+
+## CWL
+
+- CWL specification 1.0
+- Use example_inputs.yaml to see the inputs to the cwl
+- Example Command using [toil](https://toil.readthedocs.io):
+
+```bash
+    > toil-cwl-runner picard_fix_mate_information_2.21.2.cwl example_inputs.yaml
+```
+
+**If at MSK, using the JUNO cluster having installed toil version 3.19 and manually modifying [lsf.py](https://github.com/DataBiosphere/toil/blob/releases/3.19.0/src/toil/batchSystems/lsf.py#L170) by removing `type==X86_64 &&` you can use the following command**
+
+```bash
+#Using CWLTOOL
+> cwltool --singularity --non-strict /path/to/picard_fix_mate_information_1.96/picard_fix_mate_information_2.21.2.cwl /path/to/inputs.yaml
+
+#Using toil-cwl-runner
+> mkdir picardFixMate_toil_log
+> toil-cwl-runner --singularity --logFile /path/to/picardFixMate_toil_log/cwltoil.log  --jobStore /path/to/picardFixMate_jobStore --batchSystem lsf --workDir /path/to picardFixMate_toil_log --outdir . --writeLogs /path/to/picardFixMate_toil_log --logLevel DEBUG --stats --retryCount 2 --disableCaching --maxLogFileSize 20000000000 /path/to/picard_fix_mate_information_2.21.2/picard_fix_mate_information_2.21.2.cwl /path/to/inputs.yaml > picardFixMate_toil.stdout 2> picardFixMate_toil.stderr &
+```
+
+### Usage
+
+```
+usage: picard_fix_mate_information_2.21.2.cwl [-h]
+
+positional arguments:
+  job_order             Job input json file
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --memory_per_job MEMORY_PER_JOB
+                        Memory per job in megabytes
+  --memory_overhead MEMORY_OVERHEAD
+                        Memory overhead per job in megabytes
+  --number_of_threads NUMBER_OF_THREADS
+  --input INPUT         The input file to fix. This option may be specified 0
+                        or more times
+  --output_file_name OUTPUT_FILE_NAME
+                        Output file name (bam or sam). Not Required
+  --sort_order SORT_ORDER
+                        Optional sort order to output in. If not supplied
+                        OUTPUT is in the same order as INPUT.Default value:
+                        null. Possible values: {unsorted, queryname,
+                        coordinate}
+  --tmp_dir TMP_DIR     This option may be specified 0 or more times
+  --validation_stringency VALIDATION_STRINGENCY
+                        Validation stringency for all SAM files read by this
+                        program. Setting stringency to SILENT can improve
+                        performance when processing a BAM file in which
+                        variable-length data (read, qualities, tags) do not
+                        otherwise need to be decoded. Default value: STRICT.
+                        This option can be set to 'null' to clear the default
+                        value. Possible values: {STRICT,LENIENT, SILENT}
+  --bam_compression_level BAM_COMPRESSION_LEVEL
+                        Compression level for all compressed files created
+                        (e.g. BAM and GELI). Default value:5. This option can
+                        be set to 'null' to clear the default value.
+  --create_bam_index    Whether to create a BAM index when writing a
+                        coordinate-sorted BAM file. Default value:false. This
+                        option can be set to 'null' to clear the default
+                        value. Possible values:{true, false}
+```

--- a/picard_fix_mate_information_2.21.2/example_inputs.yaml
+++ b/picard_fix_mate_information_2.21.2/example_inputs.yaml
@@ -1,0 +1,12 @@
+bam_compression_level: 
+create_bam_index: true
+input:
+  class: File
+  path: "/path/to/bam"
+memory_overhead: 
+memory_per_job: 
+number_of_threads: 
+output_file_name: somename_fm.bam
+sort_order: 
+tmp_dir: 
+validation_stringency: 

--- a/picard_fix_mate_information_2.21.2/picard_fix_mate_information_2.21.2.cwl
+++ b/picard_fix_mate_information_2.21.2/picard_fix_mate_information_2.21.2.cwl
@@ -1,0 +1,161 @@
+class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  dct: 'http://purl.org/dc/terms/'
+  doap: 'http://usefulinc.com/ns/doap#'
+  foaf: 'http://xmlns.com/foaf/0.1/'
+id: picard_fix_mate_information_1.96
+baseCommand:
+  - java
+inputs:
+  - id: memory_per_job
+    type: int?
+    doc: Memory per job in megabytes
+  - id: memory_overhead
+    type: int?
+    doc: Memory overhead per job in megabytes
+  - id: number_of_threads
+    type: int?
+  - id: input
+    type: File
+    inputBinding:
+      position: 0
+      prefix: I=
+      separate: false
+    doc: The input file to fix.  This option may be specified 0 or more times
+    secondaryFiles:
+      - ^.bai
+  - id: output_file_name
+    type: string?
+    doc: >-
+        Output file name (bam or sam). Not Required
+  - id: sort_order
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: SO=
+      separate: false
+    doc: >-
+      Optional sort order to output in. If not supplied OUTPUT is in the same
+      order as INPUT.Default value: null. Possible values: {unsorted, queryname,
+      coordinate}
+  - id: tmp_dir
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: TMP_DIR=
+      separate: false
+    doc: This option may be specified 0 or more times
+  - id: validation_stringency
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+    doc: >-
+      Validation stringency for all SAM files read by this program.  Setting
+      stringency to SILENT can improve performance when processing a BAM file in
+      which variable-length data (read, qualities, tags) do not otherwise need
+      to be decoded.  Default value: STRICT. This option can be set to 'null' to
+      clear the default value. Possible values: {STRICT,LENIENT, SILENT}
+  - id: bam_compression_level
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: COMPRESSION_LEVEL=
+      separate: false
+    doc: >-
+      Compression level for all compressed files created (e.g. BAM and GELI). 
+      Default value:5. This option can be set to 'null' to clear the default
+      value.
+  - default: true
+    id: create_bam_index
+    type: boolean?
+    inputBinding:
+      position: 0
+      prefix: CREATE_INDEX=true
+    doc: >-
+      Whether to create a BAM index when writing a coordinate-sorted BAM file. 
+      Default value:false. This option can be set to 'null' to clear the default
+      value. Possible values:{true, false}
+outputs:
+  - id: bam
+    type: File
+    outputBinding:
+      glob: |-
+        ${
+            if(inputs.output_file_name){
+                return inputs.output_file_name
+            } else {
+                return inputs.input.basename.replace(/.bam/,'_fm.bam')
+            }
+        } 
+    secondaryFiles:
+      - ^.bai
+label: picard_fix_mate_information_1.96
+arguments:
+  - position: 0
+    valueFrom: |-
+      ${
+        if(inputs.memory_per_job && inputs.memory_overhead) {
+          if(inputs.memory_per_job % 1000 == 0) {
+            return "-Xmx" + (inputs.memory_per_job/1000).toString() + "G"
+          }
+          else {
+            return "-Xmx" + Math.floor((inputs.memory_per_job/1000)).toString() + "G"
+          }
+        }
+        else if (inputs.memory_per_job && !inputs.memory_overhead){
+          if(inputs.memory_per_job % 1000 == 0) {
+            return "-Xmx" + (inputs.memory_per_job/1000).toString() + "G"
+          }
+          else {
+            return "-Xmx" + Math.floor((inputs.memory_per_job/1000)).toString() + "G"
+          }
+        }
+        else if(!inputs.memory_per_job && inputs.memory_overhead){
+          return "-Xmx15G"
+        }
+        else {
+            return "-Xmx15G"
+        }
+      }
+  - position: 0
+    prefix: '-jar'
+    valueFrom: /usr/local/bin/FixMateInformation.jar
+  - position: 0
+    prefix: O=
+    separate: false
+    valueFrom: |-
+      ${
+          if(inputs.output_file_name){
+              return inputs.output_file_name
+          } else {
+              return inputs.input.basename.replace(/.bam/,'_fm.bam')
+          }
+      }
+requirements:
+  - class: ResourceRequirement
+    ramMin: 16000
+    coresMin: 2
+  - class: DockerRequirement
+    dockerPull: 'mskaccess/picard_1.96:0.6.2'
+  - class: InlineJavascriptRequirement
+'dct:contributor':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'dct:creator':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'doap:release':
+  - class: 'doap:Version'
+    'doap:name': picard
+    'doap:revision': 1.96

--- a/picard_fix_mate_information_2.21.2/picard_fix_mate_information_2.21.2.cwl
+++ b/picard_fix_mate_information_2.21.2/picard_fix_mate_information_2.21.2.cwl
@@ -5,7 +5,7 @@ $namespaces:
   doap: 'http://usefulinc.com/ns/doap#'
   foaf: 'http://xmlns.com/foaf/0.1/'
   sbg: 'https://www.sevenbridges.com/'
-id: picard_fix_mate_information_2.21.2
+id: picard_fix_mate_information_2_21_2
 baseCommand:
   - java
 inputs:
@@ -92,7 +92,7 @@ outputs:
         } 
     secondaryFiles:
       - ^.bai
-label: picard_fix_mate_information_1.96
+label: picard_fix_mate_information_2.21.2
 arguments:
   - position: 0
     valueFrom: |-

--- a/picard_fix_mate_information_2.21.2/picard_fix_mate_information_2.21.2.cwl
+++ b/picard_fix_mate_information_2.21.2/picard_fix_mate_information_2.21.2.cwl
@@ -4,7 +4,8 @@ $namespaces:
   dct: 'http://purl.org/dc/terms/'
   doap: 'http://usefulinc.com/ns/doap#'
   foaf: 'http://xmlns.com/foaf/0.1/'
-id: picard_fix_mate_information_1.96
+  sbg: 'https://www.sevenbridges.com/'
+id: picard_fix_mate_information_2.21.2
 baseCommand:
   - java
 inputs:
@@ -27,8 +28,7 @@ inputs:
       - ^.bai
   - id: output_file_name
     type: string?
-    doc: >-
-        Output file name (bam or sam). Not Required
+    doc: Output file name (bam or sam). Not Required
   - id: sort_order
     type: string?
     inputBinding:
@@ -122,7 +122,9 @@ arguments:
       }
   - position: 0
     prefix: '-jar'
-    valueFrom: /usr/local/bin/FixMateInformation.jar
+    valueFrom: /usr/picard/picard.jar
+  - position: 0
+    valueFrom: FixMateInformation
   - position: 0
     prefix: O=
     separate: false
@@ -136,10 +138,10 @@ arguments:
       }
 requirements:
   - class: ResourceRequirement
-    ramMin: 16000
+    ramMin: 17000
     coresMin: 2
   - class: DockerRequirement
-    dockerPull: 'mskaccess/picard_1.96:0.6.2'
+    dockerPull: 'broadinstitute/picard:2.21.2'
   - class: InlineJavascriptRequirement
 'dct:contributor':
   - class: 'foaf:Organization'
@@ -158,4 +160,4 @@ requirements:
 'doap:release':
   - class: 'doap:Version'
     'doap:name': picard
-    'doap:revision': 1.96
+    'doap:revision': 2.21.2

--- a/picard_hsmetrics_2.21.2/README.md
+++ b/picard_hsmetrics_2.21.2/README.md
@@ -1,0 +1,87 @@
+# CWL for running Picard - CollectAlignmentSummaryMetrics
+
+## Version of tools in docker image
+
+| Tool	| Version	| Location	|
+|---	|---	|---	|
+| picard  	| 2.8.1  	|  https://github.com/broadinstitute/picard/releases/download/2.21.2/picard.jar	|
+
+
+## CWL
+
+- CWL specification 1.0
+- Use example_inputs.yaml to see the inputs to the cwl
+- Example Command using [toil](https://toil.readthedocs.io):
+
+```bash
+> toil-cwl-runner picard_hsmetrics_2.21.2.cwl example_inputs.yaml
+```
+
+### Usage
+
+```bash
+> usage: picard_hsmetrics_2.21.2.cwl [-h]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --bait_intervals BAIT_INTERVALS
+                        An interval list file that contains the locations of
+                        the baits used. Default value: null. This option must
+                        be specified at least 1 times.
+  --bait_set_name BAIT_SET_NAME
+                        Bait set name. If not provided it is inferred from the
+                        filename of the bait intervals. Default value: null
+  --minimum_mapping_quality MINIMUM_MAPPING_QUALITY
+                        Minimum mapping quality for a read to contribute
+                        coverage. Default value: 20. This option can be set to
+                        'null' to clear the default value.
+  --minimum_base_quality MINIMUM_BASE_QUALITY
+                        Minimum base quality for a base to contribute
+                        coverage. Default value: 20. This option can be set to
+                        'null' to clear the default value.
+  --clip_overlapping_reads
+                        True if we are to clip overlapping reads, false
+                        otherwise. Default value: true. This option can be set
+                        to 'null' to clear the default value. Possible values:
+                        {true, false}
+  --target_intervals TARGET_INTERVALS
+                        An interval list file that contains the locations of
+                        the targets. Default value: null. This option must be
+                        specified at least 1 times.
+  --input INPUT         An aligned SAM or BAM file. Required.
+  --output_file_name OUTPUT_FILE_NAME
+                        The output file to write the metrics to. Required.
+  --metric_accumulation_level METRIC_ACCUMULATION_LEVEL
+                        The level(s) at which to accumulate metrics. Default
+                        value: [ALL_READS]. This option can be set to 'null'
+                        to clear the default value. Possible values:
+                        {ALL_READS, SAMPLE, LIBRARY, READ_GROUP} This option
+                        may be specified 0 or more times. This option can be
+                        set to 'null' to clear the default list.
+  --per_target_coverage PER_TARGET_COVERAGE
+                        An optional file to output per target coverage
+                        information to. Default value: null.
+  --per_base_coverage PER_BASE_COVERAGE
+                        An optional file to output per base coverage
+                        information to. The per-base file contains one line
+                        per target base and can grow very large. It is not
+                        recommended for use with large target sets. Default
+                        value: null.
+  --near_distance NEAR_DISTANCE
+                        The maximum distance between a read and the nearest
+                        probe/bait/amplicon for the read to be considered
+                        'near probe' and included in percent selected. Default
+                        value: 250. This option can be set to 'null' to clear
+                        the default value.
+  --coverage_cap COVERAGE_CAP
+                        Parameter to set a max coverage limit for Theoretical
+                        Sensitivity calculations. Default is 200. Default
+                        value: 200. This option can be set to 'null' to clear
+                        the default value.
+  --sample_size SAMPLE_SIZE
+                        Sample Size used for Theoretical Het Sensitivity
+                        sampling. Default is 10000. Default value: 10000. This
+                        option can be set to 'null' to clear the default
+                        value.
+
+```

--- a/picard_hsmetrics_2.21.2/example_inputs.yaml
+++ b/picard_hsmetrics_2.21.2/example_inputs.yaml
@@ -1,0 +1,24 @@
+bait_intervals:
+  class: File
+  metadata: {}
+  path: 'picard_baits.interval_list'
+  secondaryFiles: []
+bait_set_name: null
+clip_overlapping_reads: null
+coverage_cap: null
+input:
+  class: File
+  path: 'test_bam.bam'
+metric_accumulation_level: null
+minimum_base_quality: null
+minimum_mapping_quality: null
+near_distance: null
+output_file_name: null
+per_base_coverage: null
+per_target_coverage: null
+sample_size: null
+target_intervals:
+  class: File
+  metadata: {}
+  path: 'picard_targets.interval_list'
+  secondaryFiles: []

--- a/picard_hsmetrics_2.21.2/picard_hsmetrics_2.21.2.cwl
+++ b/picard_hsmetrics_2.21.2/picard_hsmetrics_2.21.2.cwl
@@ -5,7 +5,7 @@ $namespaces:
   doap: 'http://usefulinc.com/ns/doap#'
   foaf: 'http://xmlns.com/foaf/0.1/'
   sbg: 'https://www.sevenbridges.com/'
-id: picard_hsmetrics_2_8_1
+id: picard_hsmetrics_2_21_2
 baseCommand:
   - java
 inputs:
@@ -15,48 +15,71 @@ inputs:
       position: 0
       prefix: BAIT_INTERVALS=
       separate: false
+    doc: >-
+      An interval list file that contains the locations of the baits used.
+      Default value: null. This option must be specified at least 1 times.
   - id: bait_set_name
     type: string?
     inputBinding:
       position: 0
       prefix: BAIT_SET_NAME=
       separate: false
+    doc: >-
+      Bait set name. If not provided it is inferred from the filename of the
+      bait intervals. Default value: null
   - id: minimum_mapping_quality
     type: int?
     inputBinding:
       position: 0
       prefix: MINIMUM_MAPPING_QUALITY=
       separate: false
+    doc: >-
+      Minimum mapping quality for a read to contribute coverage. Default value:
+      20. This option can be set to 'null' to clear the default value.
   - id: minimum_base_quality
     type: int?
     inputBinding:
       position: 0
       prefix: MINIMUM_BASE_QUALITY=
       separate: false
+    doc: >-
+      Minimum base quality for a base to contribute coverage. Default value: 20.
+      This option can be set to 'null' to clear the default value.
   - id: clip_overlapping_reads
     type: boolean?
     inputBinding:
       position: 0
       prefix: CLIP_OVERLAPPING_READS=true
       separate: false
+    doc: >-
+      True if we are to clip overlapping reads, false otherwise. Default value:
+      true. This option can be set to 'null' to clear the default value.
+      Possible values: {true, false}
   - id: target_intervals
     type: File?
     inputBinding:
       position: 0
       prefix: TARGET_INTERVALS=
       separate: false
+    doc: >-
+      An interval list file that contains the locations of the targets. Default
+      value: null. This option must be specified at least 1 times.
   - id: input
     type: File
     inputBinding:
       position: 0
       prefix: INPUT=
       separate: false
+    doc: An aligned SAM or BAM file. Required.
+    secondaryFiles:
+      - ^.bai
   - id: output_file_name
     type: string?
     inputBinding:
       position: 0
       prefix: OUTPUT=
       separate: false
+    doc: The output file to write the metrics to. Required.
   - id: metric_accumulation_level
     type:
       - 'null'
@@ -71,36 +94,62 @@ inputs:
       position: 0
       prefix: METRIC_ACCUMULATION_LEVEL=
       separate: false
+    doc: >-
+      The level(s) at which to accumulate metrics. Default value: [ALL_READS].
+      This option can be set to 'null' to clear the default value. Possible
+      values: {ALL_READS, SAMPLE, LIBRARY, READ_GROUP} This option may be
+      specified 0 or more times. This option can be set to 'null' to clear the
+      default list.
   - id: per_target_coverage
     type: File?
     inputBinding:
       position: 0
       prefix: PER_TARGET_COVERAGE=
       separate: false
+    doc: >-
+      An optional file to output per target coverage information to. Default
+      value: null.
   - id: per_base_coverage
     type: File?
     inputBinding:
       position: 0
       prefix: PER_BASE_COVERAGE=
       separate: false
+    doc: >-
+      An optional file to output per base coverage information to. The per-base
+      file contains one line per target base and can grow very large. It is not
+      recommended for use with large target sets. Default value: null.
   - id: near_distance
     type: int?
     inputBinding:
       position: 0
       prefix: NEAR_DISTANCE=
       separate: false
+    doc: >-
+      The maximum distance between a read and the nearest probe/bait/amplicon
+      for the read to be considered 'near probe' and included in percent
+      selected. Default value: 250. This option can be set to 'null' to clear
+      the default value.
   - id: coverage_cap
     type: int?
     inputBinding:
       position: 0
       prefix: COVERAGE_CAP=
       separate: false
+    doc: >-
+      Parameter to set a max coverage limit for Theoretical Sensitivity
+      calculations. Default is 200. Default value: 200. This option can be set
+      to 'null' to clear the default value.
   - id: sample_size
     type: int?
     inputBinding:
       position: 0
       prefix: SAMPLE_SIZE=
       separate: false
+    doc: >-
+      Sample Size used for Theoretical Het Sensitivity sampling. Default is
+      10000. Default value: 10000. This option can be set to 'null' to clear the
+      default value.
 outputs:
   - id: hs_metrics_file
     type: File?
@@ -113,11 +162,11 @@ outputs:
                 return inputs.input.basename.replace(/.bam/,'.hsmetrics')
             }
         }
-label: picard_hsmetrics_2.8.1
+label: picard_hsmetrics_2.21.2
 arguments:
   - position: 0
     prefix: '-jar'
-    valueFrom: /usr/local/bin/picard.jar
+    valueFrom: /usr/picard/picard.jar
   - position: 0
     valueFrom: CollectHsMetrics
   - position: 0
@@ -135,9 +184,8 @@ requirements:
     ramMin: 4000
     coresMin: 1
   - class: DockerRequirement
-    dockerPull: 'mskaccess/picard:0.6.2'
+    dockerPull: 'broadinstitute/picard:2.21.2'
   - class: InlineJavascriptRequirement
-
 'dct:contributor':
   - class: 'foaf:Organization'
     'foaf:member':
@@ -155,4 +203,4 @@ requirements:
 'doap:release':
   - class: 'doap:Version'
     'doap:name': hsmetrics
-    'doap:revision': 2.8.1
+    'doap:revision': 2.21.2

--- a/picard_hsmetrics_2.21.2/picard_hsmetrics_2.21.2.cwl
+++ b/picard_hsmetrics_2.21.2/picard_hsmetrics_2.21.2.cwl
@@ -197,8 +197,8 @@ requirements:
   - class: 'foaf:Organization'
     'foaf:member':
       - class: 'foaf:Person'
-        'foaf:mbox': 'mailto:johnsoni@mskcc.org'
-        'foaf:name': Ian Johnson
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
     'foaf:name': Memorial Sloan Kettering Cancer Center
 'doap:release':
   - class: 'doap:Version'

--- a/picard_hsmetrics_2.21.2/picard_hsmetrics_2.21.2.cwl
+++ b/picard_hsmetrics_2.21.2/picard_hsmetrics_2.21.2.cwl
@@ -1,0 +1,158 @@
+class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  dct: 'http://purl.org/dc/terms/'
+  doap: 'http://usefulinc.com/ns/doap#'
+  foaf: 'http://xmlns.com/foaf/0.1/'
+  sbg: 'https://www.sevenbridges.com/'
+id: picard_hsmetrics_2_8_1
+baseCommand:
+  - java
+inputs:
+  - id: bait_intervals
+    type: File
+    inputBinding:
+      position: 0
+      prefix: BAIT_INTERVALS=
+      separate: false
+  - id: bait_set_name
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: BAIT_SET_NAME=
+      separate: false
+  - id: minimum_mapping_quality
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: MINIMUM_MAPPING_QUALITY=
+      separate: false
+  - id: minimum_base_quality
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: MINIMUM_BASE_QUALITY=
+      separate: false
+  - id: clip_overlapping_reads
+    type: boolean?
+    inputBinding:
+      position: 0
+      prefix: CLIP_OVERLAPPING_READS=true
+      separate: false
+  - id: target_intervals
+    type: File?
+    inputBinding:
+      position: 0
+      prefix: TARGET_INTERVALS=
+      separate: false
+  - id: input
+    type: File
+    inputBinding:
+      position: 0
+      prefix: INPUT=
+      separate: false
+  - id: output_file_name
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: OUTPUT=
+      separate: false
+  - id: metric_accumulation_level
+    type:
+      - 'null'
+      - type: enum
+        symbols:
+          - ALL_READS
+          - SAMPLE
+          - LIBRARY
+          - READ_GROUP
+        name: metric_accumulation_level
+    inputBinding:
+      position: 0
+      prefix: METRIC_ACCUMULATION_LEVEL=
+      separate: false
+  - id: per_target_coverage
+    type: File?
+    inputBinding:
+      position: 0
+      prefix: PER_TARGET_COVERAGE=
+      separate: false
+  - id: per_base_coverage
+    type: File?
+    inputBinding:
+      position: 0
+      prefix: PER_BASE_COVERAGE=
+      separate: false
+  - id: near_distance
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: NEAR_DISTANCE=
+      separate: false
+  - id: coverage_cap
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: COVERAGE_CAP=
+      separate: false
+  - id: sample_size
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: SAMPLE_SIZE=
+      separate: false
+outputs:
+  - id: hs_metrics_file
+    type: File?
+    outputBinding:
+      glob: |-
+        ${
+            if(inputs.output_file_name){
+                return inputs.output_file_name
+            } else {
+                return inputs.input.basename.replace(/.bam/,'.hsmetrics')
+            }
+        }
+label: picard_hsmetrics_2.8.1
+arguments:
+  - position: 0
+    prefix: '-jar'
+    valueFrom: /usr/local/bin/picard.jar
+  - position: 0
+    valueFrom: CollectHsMetrics
+  - position: 0
+    prefix: OUTPUT=
+    valueFrom: |-
+      ${
+          if(inputs.output_file_name){
+              return inputs.output_file_name
+          } else {
+              return inputs.input.basename.replace(/.bam/,'.hsmetrics')
+          }
+      }
+requirements:
+  - class: ResourceRequirement
+    ramMin: 4000
+    coresMin: 1
+  - class: DockerRequirement
+    dockerPull: 'mskaccess/picard:0.6.2'
+  - class: InlineJavascriptRequirement
+
+'dct:contributor':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:johnsoni@mskcc.org'
+        'foaf:name': Ian Johnson
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'dct:creator':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:johnsoni@mskcc.org'
+        'foaf:name': Ian Johnson
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'doap:release':
+  - class: 'doap:Version'
+    'doap:name': hsmetrics
+    'doap:revision': 2.8.1

--- a/picard_mark_duplicates_2.21.2/README.md
+++ b/picard_mark_duplicates_2.21.2/README.md
@@ -1,0 +1,77 @@
+# CWL for running Picard - MarkDuplicates
+
+## Version of tools in docker image
+
+| Tool	| Version	| Location	|
+|---	|---	|---	|
+| picard  	| 2.21.2  	|  https://github.com/broadinstitute/picard/releases/download/2.21.2/picard.jar	|
+
+
+## CWL
+
+- CWL specification 1.0
+- Use example_inputs.yaml to see the inputs to the cwl
+- Example Command using [toil](https://toil.readthedocs.io):
+
+```bash
+    > toil-cwl-runner picard_mark_duplicates_2.21.2.cwl example_inputs.yaml
+```
+
+### Usage
+
+```bash
+usage: picard_mark_duplicates_2.21.2.cwl [-h]
+
+positional arguments:
+  job_order             Job input json file
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --memory_per_job MEMORY_PER_JOB
+                        Memory per job in megabytes
+  --memory_overhead MEMORY_OVERHEAD
+                        Memory overhead per job in megabytes
+  --number_of_threads NUMBER_OF_THREADS
+  --input INPUT         Input file (bam or sam). Required.
+  --output_file_name OUTPUT_FILE_NAME
+                        Output file (bam or sam).
+  --duplication_metrics DUPLICATION_METRICS
+                        File to write duplication metrics to Required.
+  --assume_sort_order ASSUME_SORT_ORDER
+                        Optional sort order to output in. If not supplied
+                        OUTPUT is in the same order as INPUT.Default value:
+                        null. Possible values: {unsorted, queryname,
+                        coordinate}
+  --tmp_dir TMP_DIR     This option may be specified 0 or more times
+  --validation_stringency VALIDATION_STRINGENCY
+                        Validation stringency for all SAM files read by this
+                        program. Setting stringency to SILENT can improve
+                        performance when processing a BAM file in which
+                        variable-length data (read, qualities, tags) do not
+                        otherwise need to be decoded. Default value: STRICT.
+                        This option can be set to 'null' to clear the default
+                        value. Possible values: {STRICT,LENIENT, SILENT}
+  --bam_compression_level BAM_COMPRESSION_LEVEL
+                        Compression level for all compressed files created
+                        (e.g. BAM and GELI). Default value:5. This option can
+                        be set to 'null' to clear the default value.
+  --create_bam_index    Whether to create a BAM index when writing a
+                        coordinate-sorted BAM file. Default value:false. This
+                        option can be set to 'null' to clear the default
+                        value. Possible values:{true, false}
+  --duplicate_scoring_strategy DUPLICATE_SCORING_STRATEGY
+                        The scoring strategy for choosing the non-duplicate
+                        among candidates. Default value:SUM_OF_BASE_QUALITIES.
+                        This option can be set to 'null' to clear the default
+                        value.Possible values: {SUM_OF_BASE_QUALITIES,
+                        TOTAL_MAPPED_REFERENCE_LENGTH, RANDOM}
+  --optical_duplicate_pixel_distance OPTICAL_DUPLICATE_PIXEL_DISTANCE
+                        The maximum offset between two duplicate clusters in
+                        order to consider them optical duplicates. The default
+                        is appropriate for unpatterned versions of the
+                        Illumina platform. For the patterned flowcell models,
+                        2500 is moreappropriate. For other platforms and
+                        models, users should experiment to find what works
+                        best. Default value: 100. This option can be set to
+                        'null' to clear the default value.
+```

--- a/picard_mark_duplicates_2.21.2/example_inputs.yaml
+++ b/picard_mark_duplicates_2.21.2/example_inputs.yaml
@@ -1,0 +1,15 @@
+assume_sort_order: coordinate
+bam_compression_level: null
+create_bam_index: true
+duplicate_scoring_strategy: null
+duplication_metrics: test_metrics.txt
+input:
+  class: File
+  path: /path/to/file.bam
+memory_overhead: null
+memory_per_job: null
+number_of_threads: null
+optical_duplicate_pixel_distance: null
+output_file_name: null
+tmp_dir: null
+validation_stringency: null

--- a/picard_mark_duplicates_2.21.2/picard_mark_duplicates_2.21.2.cwl
+++ b/picard_mark_duplicates_2.21.2/picard_mark_duplicates_2.21.2.cwl
@@ -1,0 +1,181 @@
+class: CommandLineTool
+cwlVersion: v1.0
+$namespaces:
+  dct: 'http://purl.org/dc/terms/'
+  doap: 'http://usefulinc.com/ns/doap#'
+  foaf: 'http://xmlns.com/foaf/0.1/'
+  sbg: 'https://www.sevenbridges.com/'
+id: picard_mark_duplicates_2_21_2
+baseCommand:
+  - java
+inputs:
+  - id: memory_per_job
+    type: int?
+    doc: Memory per job in megabytes
+  - id: memory_overhead
+    type: int?
+    doc: Memory overhead per job in megabytes
+  - id: number_of_threads
+    type: int?
+  - id: input
+    type: File
+    inputBinding:
+      position: 0
+      prefix: I=
+      separate: false
+    doc: Input file (bam or sam).  Required.
+  - id: output_file_name
+    type: string?
+    doc: Output file (bam or sam).
+  - default: '$( inputs.input.basename.replace(/.bam/, ''_md.metrics'') )'
+    id: duplication_metrics
+    type: string
+    inputBinding:
+      position: 0
+      prefix: M=
+      separate: false
+    doc: File to write duplication metrics to Required.
+  - id: assume_sort_order
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: ASO=
+      separate: false
+    doc: >-
+      Optional sort order to output in. If not supplied OUTPUT is in the same
+      order as INPUT.Default value: null. Possible values: {unsorted, queryname,
+      coordinate}
+  - id: tmp_dir
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: TMP_DIR=
+      separate: false
+    doc: This option may be specified 0 or more times
+  - id: validation_stringency
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: VALIDATION_STRINGENCY=
+      separate: false
+    doc: >-
+      Validation stringency for all SAM files read by this program.  Setting
+      stringency to SILENT can improve performance when processing a BAM file in
+      which variable-length data (read, qualities, tags) do not otherwise need
+      to be decoded.  Default value: STRICT. This option can be set to 'null' to
+      clear the default value. Possible values: {STRICT,LENIENT, SILENT}
+  - id: bam_compression_level
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: COMPRESSION_LEVEL=
+      separate: false
+    doc: >-
+      Compression level for all compressed files created (e.g. BAM and GELI). 
+      Default value:5. This option can be set to 'null' to clear the default
+      value.
+  - default: true
+    id: create_bam_index
+    type: boolean?
+    inputBinding:
+      position: 0
+      prefix: CREATE_INDEX=true
+      separate: false
+    doc: >-
+      Whether to create a BAM index when writing a coordinate-sorted BAM file. 
+      Default value:false. This option can be set to 'null' to clear the default
+      value. Possible values:{true, false}
+  - id: duplicate_scoring_strategy
+    type: string?
+    inputBinding:
+      position: 0
+      prefix: DUPLICATE_SCORING_STRATEGY=
+      separate: false
+    doc: >-
+      The scoring strategy for choosing the non-duplicate among candidates. 
+      Default value:SUM_OF_BASE_QUALITIES. This option can be set to 'null' to
+      clear the default value.Possible values: {SUM_OF_BASE_QUALITIES,
+      TOTAL_MAPPED_REFERENCE_LENGTH, RANDOM}
+  - id: optical_duplicate_pixel_distance
+    type: int?
+    inputBinding:
+      position: 0
+      prefix: OPTICAL_DUPLICATE_PIXEL_DISTANCE=
+      separate: false
+    doc: >-
+      The maximum offset between two duplicate clusters in order to consider
+      them optical duplicates. The default is appropriate for unpatterned
+      versions of the Illumina platform. For the patterned flowcell models, 2500
+      is moreappropriate. For other platforms and models, users should
+      experiment to find what works best.  Default value: 100. This option can
+      be set to 'null' to clear the default value.
+outputs:
+  - id: bam
+    type: File
+    outputBinding:
+      glob: |-
+        ${
+            if(inputs.output_file_name){
+                return inputs.output_file_name
+            } else {
+                return inputs.input.basename.replace(/.bam/,'_md.bam')
+            }
+        }
+    secondaryFiles:
+      - ^.bai
+  - id: duplication_stats
+    type: File
+    outputBinding:
+      glob: |-
+        ${
+            if(inputs.duplication_metrics){
+                return inputs.duplication_metrics
+            } else {
+                return inputs.input.basename.replace(/.bam/,'_md.metrics')
+            }
+        }
+label: picard_mark_duplicates_2.21.2
+arguments:
+  - position: 0
+    valueFrom: "${\n  if(inputs.memory_per_job && inputs.memory_overhead) {\n   \n    if(inputs.memory_per_job % 1000 == 0) {\n    \t\n      return \"-Xmx\" + (inputs.memory_per_job/1000).toString() + \"G\"\n    }\n    else {\n      \n      return \"-Xmx\" + Math.floor((inputs.memory_per_job/1000)).toString() + \"G\" \n    }\n  }\n  else if (inputs.memory_per_job && !inputs.memory_overhead){\n    \n    if(inputs.memory_per_job % 1000 == 0) {\n    \t\n      return \"-Xmx\" + (inputs.memory_per_job/1000).toString() + \"G\"\n    }\n    else {\n      \n      return \"-Xmx\" + Math.floor((inputs.memory_per_job/1000)).toString() + \"G\" \n    }\n  }\n  else if(!inputs.memory_per_job && inputs.memory_overhead){\n    \n    return \"-Xmx15G\"\n  }\n  else {\n    \n  \treturn \"-Xmx15G\"\n  }\n}"
+  - position: 0
+    prefix: '-jar'
+    valueFrom: /usr/picard/picard.jar
+  - position: 0
+    valueFrom: MarkDuplicates
+  - position: 0
+    prefix: O=
+    separate: false
+    valueFrom: |-
+      ${
+          if(inputs.output_file_name){
+              return inputs.output_file_name
+          } else {
+              return inputs.input.basename.replace(/.bam/,'_md.bam')
+          }
+      }
+requirements:
+  - class: ResourceRequirement
+    ramMin: 17000
+    coresMin: 2
+  - class: DockerRequirement
+    dockerPull: 'broadinstitute/picard:2.21.2'
+  - class: InlineJavascriptRequirement
+'dct:contributor':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'dct:creator':
+  - class: 'foaf:Organization'
+    'foaf:member':
+      - class: 'foaf:Person'
+        'foaf:mbox': 'mailto:shahr2@mskcc.org'
+        'foaf:name': Ronak Shah
+    'foaf:name': Memorial Sloan Kettering Cancer Center
+'doap:release':
+  - class: 'doap:Version'
+    'doap:name': picard
+    'doap:revision': 2.21.2


### PR DESCRIPTION
Added following tools from **Picard Tools v2.21.2**, along with `README.md` and `example_inputs.yaml`:

✔️Picard AddorReplaceReadGroups
✔️Picard MarkDuplicates
✔️Picard FixMateInformation
✔️Picard CollectAlignmentSummaryMetrics
✔️Picard CollectMultipleMetrics
✔️Picard CollectHsMetrics

- [x] Tested on Rabix and `--help` does not error out on `cwltool`