### PR TITLE
multiqc requires LC_ALL to be set

### DIFF
--- a/multiqc/1.10.1.7/multiqc.cwl
+++ b/multiqc/1.10.1.7/multiqc.cwl
@@ -58,3 +58,7 @@ hints:
     dockerPull: 'ghcr.io/msk-access/multiqc:v1.10.1.7'
 requirements:
   - class: InlineJavascriptRequirement
+  - class: EnvVarRequirement
+    envDef:
+      LC_ALL: en_US.utf-8
+      LANG: en_US.utf-8


### PR DESCRIPTION
I had this problem with sequence_qc as well, and this was the fix

```
	This system supports the C.UTF-8 locale which is recommended. You might be able to resolve your issue by exporting the following environment variables:

	    export LC_ALL=C.UTF-8
	    export LANG=C.UTF-8
```
@rhshah 