### PR TITLE
Fixing path mistake

### DIFF
--- a/delly_0.9.1/container/Dockerfile
+++ b/delly_0.9.1/container/Dockerfile
@@ -59,7 +59,7 @@ RUN cd /opt \
     && make install
 
 # Add Delly to PATH
-ENV PATH="/opt/delly-${DELLY_VERSION}/bin:${PATH}"
+ENV PATH="/opt/delly/bin:${PATH}"
 
 # by default /bin/sh
 CMD ["/bin/sh"]

--- a/delly_1.0.3/container/Dockerfile
+++ b/delly_1.0.3/container/Dockerfile
@@ -59,7 +59,7 @@ RUN cd /opt \
     && make install
 
 # Add Delly to PATH
-ENV PATH="/opt/delly-${DELLY_VERSION}/bin:${PATH}"
+ENV PATH="/opt/delly/bin:${PATH}"
 
 # by default /bin/sh
 CMD ["/bin/sh"]


### PR DESCRIPTION
I realized the path for the delly executable was badly formed. 

This fixes the path in the dockerfiles. I've also re-pushed the [images](https://github.com/orgs/msk-access/packages/container/package/delly) with this fix. 