### PR TITLE
Update vardict_app.cwl

### DIFF
--- a/vardictjava/v1.8.2/vardict_app.cwl
+++ b/vardictjava/v1.8.2/vardict_app.cwl
@@ -50,7 +50,7 @@ inputs:
   b:
     type: File?
     secondaryFiles:
-      - bam.bai
+      - ^.bai
     doc: Tumor bam
 
   c:


### PR DESCRIPTION
:heavy_check_mark: change secondary file from .bai to ^.bai to allow for secondary file.