### PR TITLE
Athena fix

### DIFF
--- a/athena/1.4.2/coverage_report_single/coverage_report_single.cwl
+++ b/athena/1.4.2/coverage_report_single/coverage_report_single.cwl
@@ -101,16 +101,17 @@ inputs:
       drastically reduce run time. If not given will use maximum available
 outputs:
   - id: coverage_report_single
-    label: coverage_report_single
     type: File
     outputBinding:
-      glob: '*_report.html'
-      outputEval: |-
+      glob: |-
         ${
-            self[0].basename = "coverage_report_single";
-            return self[0]
+            if (inputs.prefix) {
+              return inputs.prefix + '*_report.html'
+            } else {
+              return '*_report.html'
+            }
         }
-label: general_stats_parse
+label: coverage_report_single
 requirements:
   - class: DockerRequirement
     dockerPull: 'ghcr.io/msk-access/athena:1.4.2'
@@ -119,13 +120,13 @@ requirements:
   - class: 'foaf:Organization'
     'foaf:member':
       - class: 'foaf:Person'
-        'foaf:mbox': 'mailto:johnsoni@mskcc.org'
-        'foaf:name': Ian Johnson
+        'foaf:mbox': 'mailto:buehlere@mskcc.org'
+        'foaf:name': Eric Buehler
     'foaf:name': Memorial Sloan Kettering Cancer Center
 'dct:creator':
   - class: 'foaf:Organization'
     'foaf:member':
       - class: 'foaf:Person'
-        'foaf:mbox': 'mailto:johnsoni@mskcc.org'
-        'foaf:name': Ian Johnson
+        'foaf:mbox': 'mailto:buehlere@mskcc.org'
+        'foaf:name': Eric Buehler
     'foaf:name': Memorial Sloan Kettering Cancer Center

--- a/athena/1.4.2/coverage_report_single/coverage_report_single.cwl
+++ b/athena/1.4.2/coverage_report_single/coverage_report_single.cwl
@@ -47,7 +47,7 @@ inputs:
     inputBinding:
       position: 999
       prefix: '-s'
-    doc: VCF(s) of known SNPs to check coverage of (optional; i.e. HGMD, ClinVar)
+    doc: 'VCF(s) of known SNPs to check coverage of (optional; i.e. HGMD, ClinVar)'
   - id: threshold
     type: int?
     inputBinding:
@@ -102,9 +102,9 @@ inputs:
 outputs:
   - id: coverage_report_single
     label: coverage_report_single
-    type: Directory
+    type: File
     outputBinding:
-      glob: .
+      glob: '*_report.html'
       outputEval: |-
         ${
             self[0].basename = "coverage_report_single";


### PR DESCRIPTION
### coverage_report_single.cwl changes: ###
* from directory to single file output
* file was missing .html extension now it has .html extension

 example output of report can be found here /work/bergerm1/bergerlab/charalk/projects/nucleo_qc/repos/220706_athena/nucleo_qc_generation/cwl-commandlinetools/athena/1.4.2/coverage_report_single/report1_coverage_report.html