### PR TITLE
Update coverage_stats_single.cwl

### DIFF
--- a/athena/1.4.2/coverage_report_single/coverage_report_single.cwl
+++ b/athena/1.4.2/coverage_report_single/coverage_report_single.cwl
@@ -71,7 +71,7 @@ inputs:
       position: 0
       prefix: '-n'
   - id: output
-    type: string?
+    type: 'string[]?'
     inputBinding:
       position: 0
       prefix: '-o'

--- a/athena/1.4.2/coverage_stats_single/coverage_stats_single.cwl
+++ b/athena/1.4.2/coverage_stats_single/coverage_stats_single.cwl
@@ -58,7 +58,7 @@ inputs:
       (optional) Prefix for naming output file, if not given will use name from
       per base coverage file
   - id: flagstat
-    type: string?
+    type: File?
     inputBinding:
       position: 900
       prefix: '--flagstat'


### PR DESCRIPTION
`--flagstats` input type was incorrect, causing upstream issues with athena subworkflow and nucleo_qc