### PR TITLE
bump docker version FOR CCI Utils

### DIFF
--- a/cci_utils/0.3.1/general_stats_parse.cwl
+++ b/cci_utils/0.3.1/general_stats_parse.cwl
@@ -39,7 +39,7 @@ outputs:
 label: general_stats_parse
 requirements:
   - class: DockerRequirement
-    dockerPull: 'ghcr.io/msk-access/cci_utils:0.3.1'
+    dockerPull: 'ghcr.io/msk-access/cci_utils:0.3.2'
   - class: InitialWorkDirRequirement
     listing:
       - entry: $(inputs.directory)

--- a/docs/cci_utils/general_stats_parse_0.3.1.md
+++ b/docs/cci_utils/general_stats_parse_0.3.1.md
@@ -4,7 +4,7 @@
 
 | Tool | Version | Location |
 |--- |--- |--- |
-| cci_utils   | 0.3.1  |  <https://github.com/msk-access/cci_utils> |
+| cci_utils   | 0.3.2  |  <https://github.com/msk-access/cci_utils> |
 
 ## CWL
 


### PR DESCRIPTION
✔️ update cci utils version. New cci utils version pulls picard metrics from uncollapsed_bam_stats and updates total base calculation.